### PR TITLE
Corrige projection de busca de instituicao

### DIFF
--- a/src/main/java/com/recrutai/api/institution/InstitutionMapper.java
+++ b/src/main/java/com/recrutai/api/institution/InstitutionMapper.java
@@ -46,12 +46,13 @@ public class InstitutionMapper {
 
     public InstitutionSummaryResponse mapToSummaryResponse(Institution entity) {
         if (entity == null) return null;
+        var headquarters = entity.getHeadquarters();
         return new InstitutionSummaryResponse(
                 entity.getId(),
                 entity.getName(),
                 entity.getHeadline(),
                 entity.getIndustry().getName(),
-                entity.getHeadquarters().getCity() + ", " + entity.getHeadquarters().getState()
+                headquarters != null ? headquarters.getCity() + ", " + headquarters.getState() : null
         );
     }
 

--- a/src/main/java/com/recrutai/api/institution/InstitutionRepository.java
+++ b/src/main/java/com/recrutai/api/institution/InstitutionRepository.java
@@ -21,11 +21,11 @@ public interface InstitutionRepository extends JpaRepository<Institution, Long> 
                 inst.name,
                 inst.headline,
                 ind.name,
-                concat(a.city, ', ', a.state)
+                CASE WHEN a IS NOT NULL THEN concat(a.city, ', ', a.state) ELSE NULL END
             )
             FROM Institution inst
-            JOIN Address a ON inst.headquarters.id = a.id
             JOIN Industry ind ON inst.industry.id = ind.id
+            LEFT JOIN Address a ON inst.headquarters.id = a.id
             WHERE (:name = '' OR (lower(inst.name) LIKE concat('%', lower(:name), '%')))
             """)
     List<InstitutionSummaryResponse> search(@Param("name") String name);


### PR DESCRIPTION
Ao usar `JOIN` ao inves de `LEFT JOIN`, instituicoes sem headquarters cadastrado eram ignorados pela projection. Alem disso, a concatenacao da cidade e estado do headquarters deve apenas acontecer se headquarters nao for null.